### PR TITLE
Fix tps_deform for nD (test for 3D and 4D)

### DIFF
--- a/src/ThinPlateSplines.jl
+++ b/src/ThinPlateSplines.jl
@@ -94,7 +94,7 @@ Thin-plate spline bending energy at the minimum.
 tps_energy(tps::ThinPlateSpline) = tps.λ*tr(tps.c*tps.Y')
 
 """
-	tps_deform(x2::AbstractArray, tps::ThinPlateSpline) 
+	tps_deform(x2::AbstractMatrix, tps::ThinPlateSpline) 
 
 calculate deformed locations of an input vector of positions`x2` according to thin-plate spline.
 Note that in combination with suitable interpolation packages can this be used to warp an image, but this function does not apply a warp by itself.
@@ -104,9 +104,10 @@ Yet it can be used to transform other mathematical structures rather than points
 	`x2`: coordinates of points to be deformed.
 	`tps`: the thin-plate spline structure of type `ThinPlateSpline` defining the deformation.
 """
-function tps_deform(x2::AbstractArray{T,D}, tps::ThinPlateSpline) where {T,D}
+function tps_deform(x2::AbstractMatrix{T}, tps::ThinPlateSpline) where {T}
     x1,d,c = tps.x1,tps.d,tps.c
 	d==[] && throw(ArgumentError("Affine component not available; run tps_solve with compute_affine=true."))
+	D = size(x2, 2)
     all_homo_z = cat(dims=2, ones(T, size(x2,1)), x2)
     # calculate sum of squares. Note that the summation is done outside the abs2
 	# it may be useful to join the terms below, but this seems a little harder than first thought

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,3 +44,25 @@ end
 @testset "tps_energy" begin
     @test tps_energy(tps) ≈ 0
 end
+
+@testset "Three dimensions" begin
+  start_pts = [0 0 0; 0 0 1; 0 1 0; 1 0 0]
+  end_pts = [-0.7 -0.7 0; 0 0 1; 0 1 0; 1 0 0]
+  tps = tps_solve(start_pts, end_pts, 1.0)
+  deformed = tps_deform(start_pts, tps)
+  @test size(deformed,1) == size(start_pts, 1)
+  @test size(deformed,2) == size(start_pts, 2)
+  @test deformed ≈ end_pts
+  @test tps_deform([0.5 0.5 0.5], tps) ≈ [0.85 0.85 0.5]
+end
+
+@testset "Four dimensions" begin
+  start_pts = [0 0 0 0; 0 0 0 1; 0 0 1 0; 0 1 0 0; 1 0 0 0]
+  end_pts = [-0.7 -0.7 0 0; 0 0 0 1; 0 0 1 0; 0 1 0 0; 1 0 0 0]
+  tps = tps_solve(start_pts, end_pts, 1.0)
+  deformed = tps_deform(start_pts, tps)
+  @test size(deformed,1) == size(start_pts, 1)
+  @test size(deformed,2) == size(start_pts, 2)
+  @test deformed ≈ end_pts
+  @test tps_deform([0.5 0.5 0.5 0.5], tps) ≈ [1.2 1.2 0.5 0.5]
+end


### PR DESCRIPTION
Fix `tps_deform` for n-dimensions based on size(tps, 2)

`tps_deform` was incorrectly changed to use the dimensionality of the array as the dimensionality of the system.

Rather the the input array must always be a matrix. The size of the second dimension defines the dimensionality of the system.

Fix #7