### PR TITLE
Add GeometryBasics extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,16 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 
+[weakdeps]
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+
+[extensions]
+ThinPlateSplinesGeometryBasicsExt = "GeometryBasics"
+
 [compat]
 julia = "1, 1.6, 1.7, 1.8"
 Tullio = "0.3"
+GeometryBasics = "0.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ ThinPlateSplinesGeometryBasicsExt = "GeometryBasics"
 [compat]
 julia = "1, 1.6, 1.7, 1.8"
 Tullio = "0.3"
-GeometryBasics = "0.4"
+GeometryBasics = "0.4, 0.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ThinPlateSplines"
 uuid = "1d861738-f48e-4029-b1d3-81ce6bc7f5ab"
 authors = ["Al Nejati"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/ext/ThinPlateSplinesGeometryBasicsExt.jl
+++ b/ext/ThinPlateSplinesGeometryBasicsExt.jl
@@ -1,0 +1,21 @@
+module ThinPlateSplinesGeometryBasicsExt
+    using GeometryBasics: Point
+    import ThinPlateSplines: tps_solve, tps_deform, ThinPlateSpline
+
+    function tps_solve(
+        x::AbstractVector{<:Point},
+        y::AbstractVector{<:Point},
+        λ;
+        compute_affine = true
+    )
+        x = stack(x; dims=1)
+        y = stack(y; dims=1)
+        return tps_solve(x, y, λ; compute_affine)
+    end
+
+    function tps_deform(x2::AbstractVector{<:Point}, tps::ThinPlateSpline)
+        x2 = stack(x2; dims=1)
+        deformed = tps_deform(x2, tps)
+        return Point{size(deformed,2)}.(eachrow(deformed))
+    end
+end


### PR DESCRIPTION
I'm working on an extension package that allows a `AbstractVector` of `GeometryBasics.Point`s to be compose with this package.

There may be other types to map over, so this currently a draft.